### PR TITLE
better xdebug settings for connecting from PHP Storm

### DIFF
--- a/etc/php7/conf.d/xdebug.ini
+++ b/etc/php7/conf.d/xdebug.ini
@@ -1,4 +1,7 @@
 [xdebug]
+zend_extension=xdebug.so
 xdebug.remote_enable=1
 xdebug.remote_autostart=1
 xdebug.max_nesting_level=500
+xdebug.remote_port=9500
+xdebug.remote_connect_back=1


### PR DESCRIPTION
This fixes https://github.com/wunderkraut/wundertools-image-fuzzy-php-developer/issues/2

This patch adds more xdebug settings, which allow PHPStorm to connect to php through nginx.
